### PR TITLE
Fix tests to support `resend/client` v0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^8.1.0",
         "illuminate/support": "^9.21|^10.0",
-        "resend/client": "^0.1.1",
+        "resend/client": "^0.2.0",
         "symfony/mailer": "^6.2"
     },
     "require-dev": {

--- a/tests/Transport/ResendTransportFactory.php
+++ b/tests/Transport/ResendTransportFactory.php
@@ -3,7 +3,7 @@
 use Illuminate\Mail\MailManager;
 use Resend\Client;
 use Resend\Laravel\Transport\ResendTransportFactory;
-use Resend\Responses\Email\EmailSent;
+use Resend\Responses\Email\Sent;
 use Symfony\Component\Mime\Email;
 
 test('get transport', function () {
@@ -28,7 +28,7 @@ test('send', function () {
         ->to('me@example.com')
         ->bcc('you@example.com');
 
-    $resendResult = new EmailSent('id', 'myself@example.com', 'me@example.com');
+    $resendResult = new Sent('id', 'myself@example.com', 'me@example.com');
 
     $client = mock(Client::class)->shouldReceive('sendEmail')
         ->once()


### PR DESCRIPTION
This PR updates the Laravel package to use `resend/client` v0.2. This update uses the new `Sent` response class, which was renamed from `EmailSent`.